### PR TITLE
Fix January Uprising bug

### DIFF
--- a/HPMP/events/CPLhist.txt
+++ b/HPMP/events/CPLhist.txt
@@ -14,7 +14,7 @@ country_event = {
 	trigger = {
 		NOT = { has_global_flag = january_uprising_happened }
 		tag = RUS
-		year = 1850
+		year = 1860
 		OR = {
 			is_our_vassal = CPL
 			AND = {
@@ -35,6 +35,10 @@ country_event = {
 				}
 			}
 		}
+	
+	mean_time_to_happen = { 
+		months = 40
+	}
 	
 	option = {
 		name = "EVTOPT500001A"

--- a/HPMP/events/CPLhist.txt
+++ b/HPMP/events/CPLhist.txt
@@ -17,6 +17,7 @@ country_event = {
 		year = 1860
 		OR = {
 			is_our_vassal = CPL
+			is_our_vassal = POL
 			AND = {
 				any_owned_province = { is_core = CPL }
 				NOT = {

--- a/HPMP/events/CPLhist.txt
+++ b/HPMP/events/CPLhist.txt
@@ -15,7 +15,18 @@ country_event = {
 		NOT = { has_global_flag = january_uprising_happened }
 		tag = RUS
 		year = 1850
-		any_owned_province = { is_core = CPL }
+		OR = {
+			is_our_vassal = CPL
+			AND = {
+				any_owned_province = { is_core = CPL }
+				NOT = {
+					exists = CPL
+				}
+				NOT = {
+					exists = POL
+				}
+			}
+		}
 		OR = {
 			has_recently_lost_war = yes	
 			AND = {


### PR DESCRIPTION
January Uprising fires when Congress Poland is independent, because the only trigger is for Russia to own CPL provinces. Now the event fires only if either CPL is a Russian puppet, or if CPL and Poland don't exist and Russia owns CPL cores.

Also per your request, year changed to 1860 and MTTH to 40 months.