### PR TITLE
Fix France annexing Mayotte d1

### DIFF
--- a/HPMP/decisions/France.txt
+++ b/HPMP/decisions/France.txt
@@ -335,7 +335,7 @@ political_decisions = {
 		
 		allow = {
 			war = no
-			medicine = 1
+			idealism = 1
 		}
 		
 		effect = {
@@ -802,4 +802,3 @@ devil_island = {
 }
 
 }
-


### PR DESCRIPTION
Because France now starts with Medicine tech, it annexes Mayotte d1. To fix this, decision is now tied with Idealism - tech sharing the 1840 unlock date with Medicine.