### PR TITLE
Fix syntax errors

### DIFF
--- a/HPMP/decisions/India.txt
+++ b/HPMP/decisions/India.txt
@@ -752,18 +752,14 @@ political_decisions = {
 		}
 
 		allow = {
-			OR = {
 				owns = 3286
-			}
 		}
 		
 		
 		effect = {
 			any_owned = {
 				limit = { NOT = { has_province_modifier = trade_center }
-				OR = {
-					province_id = 3286
-					}
+				province_id = 3286
 				}
 			add_province_modifier = {
 				name = trade_center

--- a/HPMP/decisions/India.txt
+++ b/HPMP/decisions/India.txt
@@ -757,13 +757,10 @@ political_decisions = {
 		
 		
 		effect = {
-			any_owned = {
-				limit = { NOT = { has_province_modifier = trade_center }
-				province_id = 3286
-				}
-			add_province_modifier = {
-				name = trade_center
-				duration = 3650
+			3286 = {
+				add_province_modifier = {
+					name = trade_center
+					duration = 3650
 				}
 			}
 		}

--- a/HPMP/history/provinces/germany/546 - Stettin.txt
+++ b/HPMP/history/provinces/germany/546 - Stettin.txt
@@ -3,7 +3,8 @@ controller = PRU
 add_core = PRU
 add_core = GER
 trade_goods = fish
-life_rating = 40naval_base = 1
+life_rating = 40
+naval_base = 1
 1861.1.1 = {
 	state_building = {
 		level = 1


### PR DESCRIPTION
based validator pointing out critical syntax errors

in India it's redundant OR with one argument, in Stettin it's no space/newline between liferating and naval base which can make some analyzers crash